### PR TITLE
fix: package command for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Building
 
 Running
 -------
-`npm run run` will run the bundled application. Note, you will have to build it first.
+`npm run start` will run the bundled application. Note, you will have to build it first.
 
 
 Packaging

--- a/packaging/jam-pack-nodegui.json
+++ b/packaging/jam-pack-nodegui.json
@@ -64,9 +64,7 @@
     "applicationTitle": "nodeguiapp",
     "nsHumanReadableCopyright": "Copyright 2023 Someone",
     "cfBundleIdentifier": "com.someapp.someapp",
-    "prePack": [
-      "mv $dmgStep_dmgResourcesDirectory/nodeguiapp $dmgStep_dmgMacOSDirectory/"
-    ]
+    "prePack": []
   }
 
 }


### PR DESCRIPTION
The package command runs into issue during dmg creation phase. I have fixed it by removing the prePack from jam-pack config, as it was unnecessary and resulting in path issue.